### PR TITLE
Add environment file for Hadoop daemons

### DIFF
--- a/group_vars/all/mapred
+++ b/group_vars/all/mapred
@@ -1,3 +1,5 @@
+mapred_service_name: hadoop-mapreduce
+
 mapred_framework: yarn
 
 mapred_map_cores:

--- a/roles/hadoop-common/tasks/main.yml
+++ b/roles/hadoop-common/tasks/main.yml
@@ -78,3 +78,11 @@
     - dfs.exclude
     - yarn.include
     - yarn.exclude
+
+- name: copy out hadoop daemon configuration file (defaults)
+  template:
+    src: etc-default-hadoop.j2
+    dest: /etc/default/hadoop
+    owner: root
+    group: root
+    mode: 0644

--- a/roles/hadoop-common/templates/etc-default-hadoop.j2
+++ b/roles/hadoop-common/templates/etc-default-hadoop.j2
@@ -1,0 +1,11 @@
+{{ ansible_managed | comment }}
+
+HADOOP_HOME={{ hadoop_home }}
+HADOOP_PREFIX={{ hadoop_home }}
+HADOOP_LIBEXEC_DIR={{ hadoop_home }}/libexec
+HADOOP_CONF_DIR={{ hadoop_conf_dir }}
+HADOOP_COMMON_HOME={{ hadoop_home }}
+HADOOP_HDFS_HOME=/usr/lib/{{ hdfs_service_name }}
+HADOOP_MAPRED_HOME=/usr/lib/{{ mapred_service_name }}
+HADOOP_YARN_HOME=/usr/lib/{{ yarn_service_name }}
+JSVC_HOME=/usr/lib/bigtop-utils

--- a/roles/journalnode/templates/hadoop-hdfs-daemon.service.j2
+++ b/roles/journalnode/templates/hadoop-hdfs-daemon.service.j2
@@ -12,6 +12,7 @@ Group=hdfs
 KillMode=process
 SuccessExitStatus=143
 RemainAfterExit=no
+EnvironmentFile=-/etc/default/hadoop
 RuntimeDirectory={{ hdfs_service_name }}
 RuntimeDirectoryMode=0755
 WorkingDirectory={{ hdfs_home_dir }}


### PR DESCRIPTION
The initscripts for the various Hadoop daemons source a file in
`/etc/default` that wasn't being included by the systemd service units.
The lack of that file caused breakages (e.g. not determining the correct
libexec directory).  Add that file, add a task to distribute it, and add
the ability to source it to the systemd units.