### PR TITLE
Refactor zookeeper role

### DIFF
--- a/group_vars/all/zookeeper
+++ b/group_vars/all/zookeeper
@@ -1,3 +1,5 @@
+zk_client_port: 2181
+
 zk_quorum:
   nn01: 1
   nn02: 2

--- a/roles/hadoop-common/templates/core-site.xml.j2
+++ b/roles/hadoop-common/templates/core-site.xml.j2
@@ -32,7 +32,7 @@
   <!-- ZooKeeper servers that will manage auto failover -->
   <property>
     <name>ha.zookeeper.quorum</name>
-    <value>{{ groups['zookeeper'] | join('.' + dns_domain + ':2181,')}}.{{ dns_domain }}:2181</value>
+		<value>{{ groups['zookeeper'] | join('.' + dns_domain + ':' + zk_client_port + ',') }}.{{ dns_domain }}:{{ zk_client_port }}</value>
   </property>
 
   <!-- Internal between trash cleanup runs, in minutes -->

--- a/roles/zookeeper/README.md
+++ b/roles/zookeeper/README.md
@@ -1,31 +1,111 @@
-Role Name
+ZooKeeper
 =========
 
-A brief description of the role goes here.
+This role will install and configure a ZooKeeper ensemble.
 
 Requirements
 ------------
 
-Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+This role was written for Ansible version 2.6 and later.  However, this should
+work on most previous versions, as only core functionality is used.
 
 Role Variables
 --------------
 
-A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+### `zk_service_name`
+
+This should probably be left set to `zookeeper`.  It is used to build the names
+of ZooKeeper's home and data directories.
+
+### `zk_home_dir`
+
+Home directory of the `zookeeper` user that gets created when the
+`zookeeper-server` Bigtop package is installed.  Default will be
+`/var/lib/zookeeper`.
+
+### `zk_data_dir`
+
+This is where the ZooKeeper will store snapshots of its database.  Does not
+_necessarily_ need to be the same as `zk_home_dir`, but there is likely no
+reason to separate them.  Default will be `/var/lib/zookeeper`.
+
+### `zk_max_client_cnxns`
+
+Number of concurrent connections that a _single_ client can have to a _single_
+member of the ensemble.  Default is set to 50.
+
+### `zk_tick_time`
+
+Number of milliseconds in each 'tick'.  Default is set to 2000.
+
+### `zk_init_limit`
+
+The amount of time that the initial synchronization phase can take, measured in
+'ticks' as defined in `zk_tick_time`.  Default is set to 10.
+
+### `zk_sync_limit`
+
+The amount of time that represents how far out of date a server can be from a
+leader, measured in 'ticks' as defined in `zk_tick_time`.  Default is set to 5.
+
+For anything measured in ticks, multiply the value that you set by
+`zk_tick_time` to get the amount of time (in milliseconds) that the value
+represents.  For example, take a configuration like the following.  
+
+```
+zk_tick_time: 2000
+zk_init_limit: 10
+zk_sync_limit: 5
+```
+
+Here, `zk_init_limit` is equal to 20000 ms (i.e. 20 s) and `zk_sync_limit` is
+equal to 10000 ms (10 s).  
+
+*The following two variables should be set in `group_vars/all` (or under
+`group_vars/all/` if using multiple files for all inventory variables).*
+
+### `zk_client_port`
+
+The port that ZooKeeper clients will need to connect to (i.e. the port the
+server should listen on).
+
+### `zk_quorum`
+
+This is a dictionary that uses the host names of your ZooKeeper servers as the
+_keys_ and the _values_ should be the ZooKeeper IDs that will correspond to
+those servers.  For example, if your ZooKeeper hosts are named zk01, zk02, and
+zk03, your `zk_quorum` variable might look like this:
+
+```
+zk_quorum:
+  zk01: 1
+  zk02: 2
+  zk03: 3
+```
+
+The reason that these are meant to be set at the inventory level is because
+hosts that do not run this role might need them as well.  As an example, this
+role is meant to be run as part of a Hadoop installation.  Configuration files
+that have nothing to do with ZooKeeper itself will need to access these values
+if HDFS HA is enabled.  Rather than define these variables in two places (once
+at inventory level and as a default as a part of this role), they are only
+defined once in `group_vars/all`.
 
 Dependencies
 ------------
 
-A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+No role dependencies.
 
 Example Playbook
 ----------------
 
-Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+Example usage:
 
-    - hosts: servers
-      roles:
-         - { role: username.rolename, x: 42 }
+```
+- hosts: servers
+  roles:
+     - { role: zookeeper }
+```
 
 License
 -------
@@ -35,4 +115,4 @@ BSD
 Author Information
 ------------------
 
-An optional section for the role authors to include contact information, or a website (HTML is not allowed).
+Marc J. Patton

--- a/roles/zookeeper/defaults/main.yml
+++ b/roles/zookeeper/defaults/main.yml
@@ -7,4 +7,3 @@ zk_max_client_cnxns: 50
 zk_tick_time: 2000
 zk_init_limit: 10
 zk_sync_limit: 5
-zk_client_port: 2181


### PR DESCRIPTION
Place certain configuration values (`zk_client_port`) at the inventory
level.  Document the zookeeper role.  Change the hadoop-common role to
use the variable for `zk_client_port` instead of a hardcoded value.