### PR TITLE
Support systemd only

### DIFF
--- a/roles/hdfs/tasks/main.yml
+++ b/roles/hdfs/tasks/main.yml
@@ -22,7 +22,7 @@
     mode: 0644
 
 - name: explicitly stop/disable {{ hdfs_daemon }}
-  service:
+  systemd:
     name: "{{ hdfs_daemon_name }}"
     state: stopped
     enabled: no

--- a/roles/yarn/tasks/main.yml
+++ b/roles/yarn/tasks/main.yml
@@ -14,7 +14,7 @@
     mode: 0644
 
 - name: explicitly stop/disable {{ yarn_daemon }}
-  service:
+  systemd:
     name: "{{ yarn_daemon_name }}"
     state: stopped
     enabled: no

--- a/utils/services/hdfs/restart-hdfs.yml
+++ b/utils/services/hdfs/restart-hdfs.yml
@@ -3,7 +3,7 @@
   serial: 1
   tasks:
     - name: restart journalnode service
-      service:
+      systemd:
         name: hadoop-hdfs-journalnode
         state: restarted
     
@@ -18,12 +18,12 @@
   serial: 1
   tasks:
     - name: restart zkfc
-      service:
+      systemd:
         name: hadoop-hdfs-zkfc
         state: restarted
 
     - name: restart namenode service
-      service:
+      systemd:
         name: hadoop-hdfs-namenode
         state: restarted
 
@@ -37,7 +37,7 @@
 - hosts: datanodes
   tasks:
     - name: restart datanode service
-      service:
+      systemd:
         name: hadoop-hdfs-datanode
         state: restarted
   tags: ["hdfs", "datanodes"]

--- a/utils/services/hdfs/start-hdfs.yml
+++ b/utils/services/hdfs/start-hdfs.yml
@@ -2,7 +2,7 @@
 - hosts: journalnodes
   tasks:
     - name: start journalnodes
-      service:
+      systemd:
         name: hadoop-hdfs-journalnode
         state: started
         enabled: no
@@ -27,7 +27,7 @@
       when: ( format_hdfs == true )
 
     - name: start first namenode
-      service:
+      systemd:
         name: hadoop-hdfs-namenode
         state: started
         enabled: no
@@ -46,7 +46,7 @@
       when: ( format_hdfs == true )
 
     - name: start second namenode
-      service:
+      systemd:
         name: hadoop-hdfs-namenode
         state: started
         enabled: no
@@ -61,7 +61,7 @@
         delay: 5
 
     - name: start zkfc
-      service:
+      systemd:
         name: hadoop-hdfs-zkfc
         state: started
         enabled: no
@@ -70,7 +70,7 @@
 - hosts: datanodes
   tasks:
     - name: start datanodes
-      service:
+      systemd:
         name: hadoop-hdfs-datanode
         state: started
         enabled: no

--- a/utils/services/hdfs/stop-hdfs.yml
+++ b/utils/services/hdfs/stop-hdfs.yml
@@ -2,7 +2,7 @@
 - hosts: datanodes
   tasks:
     - name: stop datanodes
-      service:
+      systemd:
         name: hadoop-hdfs-datanode
         state: stopped
   tags: ["hdfs", "datanodes"]
@@ -10,12 +10,12 @@
 - hosts: namenodes
   tasks:
     - name: stop namenodes
-      service:
+      systemd:
         name: hadoop-hdfs-namenode
         state: stopped
 
     - name: stop zkfc
-      service:
+      systemd:
         name: hadoop-hdfs-zkfc
         state: stopped
   tags: ["hdfs", "namenodes", "journalnodes"]
@@ -23,7 +23,7 @@
 - hosts: journalnodes
   tasks:
     - name: stop journalnodes
-      service:
+      systemd:
         name: hadoop-hdfs-journalnode
         state: stopped
   tags: ["hdfs", "journalnodes"]

--- a/utils/services/hive/restart-hive.yml
+++ b/utils/services/hive/restart-hive.yml
@@ -2,7 +2,7 @@
 - hosts: hive-metastore
   tasks:
     - name: restart the hive metastore
-      service:
+      systemd:
         name: hive-metastore
         state: restarted
   tags: ["hive", "hive-metastore"]
@@ -10,7 +10,7 @@
 - hosts: hive-server
   tasks:
     - name: restart hiveserver2
-      service:
+      systemd:
         name: hive-server2
         state: restarted
   tags: ["hive", "hive-server"]

--- a/utils/services/hive/start-hive.yml
+++ b/utils/services/hive/start-hive.yml
@@ -27,7 +27,7 @@
 - hosts: hive-metastore
   tasks:
     - name: start the hive metastore
-      service:
+      systemd:
         name: hive-metastore
         state: started
         enabled: no
@@ -36,7 +36,7 @@
 - hosts: hive-server
   tasks:
     - name: start hiveserver2
-      service:
+      systemd:
         name: hive-server2
         state: started
         enabled: no

--- a/utils/services/hive/stop-hive.yml
+++ b/utils/services/hive/stop-hive.yml
@@ -2,7 +2,7 @@
 - hosts: hive-server
   tasks:
     - name: stop hiveserver2
-      service:
+      systemd:
         name: hive-server2
         state: stopped
         enabled: no
@@ -11,7 +11,7 @@
 - hosts: hive-metastore
   tasks:
     - name: stop the hive metastore
-      service:
+      systemd:
         name: hive-metastore
         state: stopped
         enabled: no

--- a/utils/services/yarn/restart-yarn.yml
+++ b/utils/services/yarn/restart-yarn.yml
@@ -2,7 +2,7 @@
 - hosts: resourcemanagers
   tasks:
     - name: restart resourcemanager service
-      service:
+      systemd:
         name: hadoop-yarn-resourcemanager
         state: restarted
 
@@ -12,7 +12,7 @@
         port: 8030
 
     - name: restart the historyserver
-      service:
+      systemd:
         name: hadoop-yarn-historyserver
         state: restarted
   tags: ["yarn", "resourcemanagers"]
@@ -20,7 +20,7 @@
 - hosts: nodemanagers
   tasks:
     - name: restart nodemanagers
-      service:
+      systemd:
         name: hadoop-yarn-nodemanager
         state: restarted
   tags: ["yarn", "nodemanagers"]

--- a/utils/services/yarn/start-yarn.yml
+++ b/utils/services/yarn/start-yarn.yml
@@ -15,7 +15,7 @@
       tags: ["start-scheduling"]
 
     - name: start resourcemanager
-      service:
+      systemd:
         name: hadoop-yarn-resourcemanager
         state: started
         enabled: no
@@ -26,7 +26,7 @@
         port: 8030
 
     - name: start the historyserver
-      service:
+      systemd:
         name: hadoop-yarn-historyserver
         state: started
         enabled: no
@@ -42,7 +42,7 @@
 - hosts: nodemanagers
   tasks:
     - name: start nodemanagers
-      service:
+      systemd:
         name: hadoop-yarn-nodemanager
         state: started
         enabled: no

--- a/utils/services/yarn/stop-yarn.yml
+++ b/utils/services/yarn/stop-yarn.yml
@@ -19,7 +19,7 @@
 - hosts: nodemanagers
   tasks:
     - name: stop nodemanagers
-      service:
+      systemd:
         name: hadoop-yarn-nodemanager
         state: stopped
   tags: ["yarn", "nodemanagers"]
@@ -27,12 +27,12 @@
 - hosts: resourcemanagers
   tasks:
     - name: stop historyserver
-      service:
+      systemd:
         name: hadoop-yarn-historyserver
         state: stopped
 
     - name: stop resourcemanager
-      service:
+      systemd:
         name: hadoop-yarn-resourcemanager
         state: stopped
   tags: ["yarn", "resourcemanagers"]

--- a/utils/services/zookeeper/restart-zookeeper.yml
+++ b/utils/services/zookeeper/restart-zookeeper.yml
@@ -3,7 +3,7 @@
   serial: 1
   tasks:
     - name: restart zookeeper server
-      service:
+      systemd:
         name: zookeeper-server
         state: restarted
 

--- a/utils/services/zookeeper/start-zookeeper.yml
+++ b/utils/services/zookeeper/start-zookeeper.yml
@@ -2,7 +2,7 @@
 - hosts: zookeeper
   tasks:
     - name: start zookeeper servers
-      service:
+      systemd:
         name: zookeeper-server
         state: started
     

--- a/utils/services/zookeeper/stop-zookeeper.yml
+++ b/utils/services/zookeeper/stop-zookeeper.yml
@@ -2,7 +2,7 @@
 - hosts: zookeeper
   tasks:
     - name: stop zookeeper servers
-      service:
+      systemd:
         name: zookeeper-server
         state: stopped
   tags: ["zookeeper"]


### PR DESCRIPTION
Remove uses of Ansible's `service` module and replace those uses with
`systemd`.  The only OSes that are planned to be supported use systemd
anyhow.