### PR TITLE
Add hdfs_formatted fact

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ tasks (i.e. starting, stopping, and restarting services).  In particular, the
 starting all necessary services.
 
 ```
-$ ansible-playbook --extra-vars '{"format_hdfs": true}' utils/start-hadoop.yml
+$ ansible-playbook utils/start-hadoop.yml
 ```
 
 You can start specific services using Ansible tags:  
@@ -59,7 +59,7 @@ $ ansible-playbook --tags 'hive-metastore' utils/services/hive/restart-hive.yml
 Requirements
 ------------
 
-OS: CentOS 7 (fully tested on 7.4 and 7.5)  
+OS: CentOS 7 (fully tested on 7.4, 7.5, and 7.6)  
 Hadoop: 2.x  
 Java > 1.6 (but < 1.9)
 

--- a/group_vars/namenodes
+++ b/group_vars/namenodes
@@ -1,3 +1,1 @@
-format_hdfs: false
-
 hdfs_daemon: namenode

--- a/roles/hadoop-common/tasks/main.yml
+++ b/roles/hadoop-common/tasks/main.yml
@@ -86,3 +86,19 @@
     owner: root
     group: root
     mode: 0644
+
+- name: create custom facts directory
+  file:
+    name: /etc/ansible/facts.d
+    state: directory
+    owner: root
+    group: root
+
+- name: insert fact file for formatting HDFS
+  template:
+    src: hdfs_format.fact.j2
+    dest: /etc/ansible/facts.d/hdfs_format.fact
+    owner: root
+    group: root
+    mode: 0755
+  when: ( "namenodes" in group_names )

--- a/roles/hadoop-common/templates/hdfs_format.fact.j2
+++ b/roles/hadoop-common/templates/hdfs_format.fact.j2
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+{{ ansible_managed | comment }}
+
+if [[ -d {{ hdfs_name_dir }} ]]; then
+		HDFS_FORMATTED=true
+else
+		HDFS_FORMATTED=false
+fi
+
+echo "{\"hdfs_formatted\": ${HDFS_FORMATTED}}"

--- a/roles/hadoop-common/templates/hdfs_formatted.fact.j2
+++ b/roles/hadoop-common/templates/hdfs_formatted.fact.j2
@@ -3,9 +3,9 @@
 {{ ansible_managed | comment }}
 
 if [[ -d {{ hdfs_name_dir }} ]]; then
-		HDFS_FORMATTED=true
+    HDFS_FORMATTED=true
 else
-		HDFS_FORMATTED=false
+    HDFS_FORMATTED=false
 fi
 
 echo "{\"hdfs_formatted\": ${HDFS_FORMATTED}}"

--- a/utils/services/hdfs/start-hdfs.yml
+++ b/utils/services/hdfs/start-hdfs.yml
@@ -17,14 +17,14 @@
 - hosts: namenodes[0]
   tasks:
     - block:
-        - name: format hdfs
-          shell: "hdfs namenode -format {{ cluster_name }} -force"
+        - name: format hdfs if necessary
+          shell: hdfs namenode -format {{ cluster_name | quote }} -force
 
         - name: initialize hdfs shared edits directory
-          shell: "hdfs namenode -initializeSharedEdits -force"
+          shell: hdfs namenode -initializeSharedEdits -force
       become: yes
       become_user: hdfs
-      when: ( format_hdfs == true )
+      when: ( hdfs_formatted == false )
 
     - name: start first namenode
       systemd:
@@ -36,14 +36,14 @@
 - hosts: namenodes[1]
   tasks:
     - block:
-        - name: bootstrap standby namenode
-          shell: "hdfs namenode -bootstrapStandby"
+        - name: bootstrap standby namenode if necessary
+          shell: hdfs namenode -bootstrapStandby
 
         - name: format zookeeper
-          shell: "hdfs zkfc -formatZK"
+          shell: hdfs zkfc -formatZK
       become: yes
       become_user: hdfs
-      when: ( format_hdfs == true )
+      when: ( hdfs_formatted == false )
 
     - name: start second namenode
       systemd:


### PR DESCRIPTION
This fact has been added to ease of use of the `start-hadoop.yml`
playbook.  This way, whether or not HDFS has already been formatted can
be determined automatically by script, instead of relying on an operator
to change the setting.  References to the old variable have been
removed.